### PR TITLE
Restore compatibility with BBHN 1.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ I've done all of my testing with N150 USB wifi adapters that use the Ralink 5370
 Raspberry Pi Installation
 =========================
 
-1.  Download the Raspbian Wheezy 2013-07-26 disk image on your Mac/PC/whatever (http://downloads.raspberrypi.org/raspbian/images/2013-07-26-wheezy-raspbian/)
+1.  Download the Raspbian Wheezy 2013-09-10 disk image on your Mac/PC/whatever (http://downloads.raspberrypi.org/raspbian/images/raspbian-2013-09-16/)
 1.  Write the image to an SD memory card.  This involves formatting the SD card; I recommend the steps described at http://elinux.org/RPi_Easy_SD_Card_Setup
 1.  Insert the card into a Raspberry Pi
 1.  Connect the wired Ethernet port on the Pi to a network with Internet access

--- a/install.sh
+++ b/install.sh
@@ -129,11 +129,11 @@ cd /var/tmp
 git clone git://olsr.org/olsrd.git
 cd olsrd
 
-# Apply BBHN patch to olsrd
-patch -p1 < ../bbhn_packages/net/olsrd/patches/002-mode_secure-timediff-fix
-
 # Checkout the latest 0.6.6 release, have seen intermittent problems with 0.6.5
 git checkout release-0.6.6
+
+# Apply BBHN patch to olsrd
+patch -p1 < ../bbhn_packages/net/olsrd/patches/002-mode_secure-timediff-fix
 
 # patch the Makefile configuration to produce position-independent code (PIC)
 # applies only to ARM architecture (i.e. Beaglebone/Beagleboard)

--- a/install.sh
+++ b/install.sh
@@ -120,10 +120,17 @@ sudo ln -fs ../mods-available/rewrite.load
 sudo cp ${PROJECT_HOME}/src/etc/apache2/conf.d/hsmm-pi.conf /etc/apache2/conf.d/hsmm-pi.conf
 sudo service apache2 restart
 
+# Download BBHN packages (needed for olsrd patch)
+cd /var/tmp
+git clone git://ubnt.hsmm-mesh.org/bbhn_packages
+
 # Download and build olsrd
 cd /var/tmp
 git clone git://olsr.org/olsrd.git
 cd olsrd
+
+# Apply BBHN patch to olsrd
+patch -p1 < ../bbhn_packages/net/olsrd/patches/002-mode_secure-timediff-fix
 
 # Checkout the latest 0.6.6 release, have seen intermittent problems with 0.6.5
 git checkout release-0.6.6
@@ -155,6 +162,7 @@ sudo cp ${PROJECT_HOME}/src/etc/default/olsrd /etc/default/olsrd
 
 cd /var/tmp
 rm -rf /var/tmp/olsrd
+rm -rf /var/tmp/bbhn_packages
 
 sudo rm -f /etc/olsrd.conf
 sudo ln -fs /etc/olsrd/olsrd.conf /etc/olsrd.conf

--- a/src/var/www/hsmm-pi/webroot/files/olsrd/olsrd.conf.template
+++ b/src/var/www/hsmm-pi/webroot/files/olsrd/olsrd.conf.template
@@ -137,6 +137,7 @@ Interface "{wifi_adapter_name}"
 # Fisheye mechanism for TC messages 0=off, 1=on
 
 LinkQualityFishEye 1
+LinkQualityAlgorithm "etx_ffeth"
 
 
 # IP version to use (4 or 6)


### PR DESCRIPTION
This patch restores compatibility with BBHN 1.1.2.  It changes the link quality metric to match BBHN's, and also pulls in a patch that BBHN has made to the OLSRD Secure plugin.  I've tested this on my Raspberry Pi, and it's now able to talk to a Bullet M2 running BBHN 1.1.2.
