### PR TITLE
Set wired interface to come up automatically.

### DIFF
--- a/src/var/www/hsmm-pi/webroot/files/network_interfaces/interfaces.template
+++ b/src/var/www/hsmm-pi/webroot/files/network_interfaces/interfaces.template
@@ -7,6 +7,7 @@
 auto lo
 iface lo inet loopback
 
+auto {wired_adapter_name}
 iface {wired_adapter_name} inet {wired_mode}
 
 auto {wifi_adapter_name}


### PR DESCRIPTION
Otherwise, the wired interface doesn't work on the BeagleBone.  I've tested this on the Raspberry Pi as well, and it doesn't cause any problems there.
