### PR TITLE
An important bug fix and some updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ I've done all of my testing with N150 USB wifi adapters that use the Ralink 5370
 Raspberry Pi Installation
 =========================
 
-1.  Download the Raspbian Wheezy 2014-09-09 disk image on your Mac/PC/whatever (http://downloads.raspberrypi.org/raspbian/images/raspbian-2014-09-12/)
+1.  Download the Raspbian Wheezy 2015-02-16 disk image on your Mac/PC/whatever (http://downloads.raspberrypi.org/raspbian/images/raspbian-2015-02-17/)
 1.  Write the image to an SD memory card.  This involves formatting the SD card; I recommend the steps described at http://elinux.org/RPi_Easy_SD_Card_Setup
 1.  Insert the card into a Raspberry Pi
 1.  Connect the wired Ethernet port on the Pi to a network with Internet access

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 HSMM-Pi
 =======
 
-HSMM-Pi is a set of tools designed to easily configure the Raspberry Pi to function as a High-Speed Multimedia (HSMM) wireless node.  HSMM offers radio amateurs (HAMs) the ability to operate high-speed data networks in the frequencies shared with unlicenced users of 802.11 b/g/n networking equipment.  HAMs can operate HSMM at higher power with larger antennas than are available to unlicensed users.  The HSMM-Pi project makes it possible to run an HSMM mesh node on the Raspberry Pi.  The project has been tested to work on other embedded computing platforms, including the Beaglebone Black.
+HSMM-Pi is a set of tools designed to easily configure the Raspberry Pi to function as a High-Speed Multimedia (HSMM) or Broadband-Hamnet (BBHN) wireless node.  HSMM and BBHN offer radio amateurs (HAMs) the ability to operate high-speed data networks in the frequencies shared with unlicenced users of 802.11 b/g/n networking equipment.  HAMs can operate HSMM or BBHN at higher power with larger antennas than are available to unlicensed users.  The HSMM-Pi project makes it possible to run an HSMM or BBHN mesh node on the Raspberry Pi.  The project has been tested to work on other embedded computing platforms, including the BeagleBone and BeagleBone Black.
 
 The HSMM-Pi project can used by people not possessing an amateur radio license so long as they are in compliance with the transmission rules set by the FCC or the local regulating body.  This typically means sticking with the WiFi antenna provided with your WiFi adapter.
 
@@ -11,7 +11,7 @@ http://hsmmpi.wordpress.com/
 For a video tour, see the following YouTube video:
 http://www.youtube.com/watch?v=ltUAw02vfqk
 
-The project consists of a PHP web application that is used to configure and monitor the mesh node, and an installation shell script that installs dependencies and puts things in the right spots.  
+The project consists of a PHP web application that is used to configure and monitor the mesh node, and an installation shell script that installs dependencies and puts things in the right spots.
 
 The HSMM-Pi project is designed to run on Ubuntu 12.04 systems.  Rather than providing an OS image for HSMM-Pi, I've instead created an installation script that will transform a newly-imaged host into an HSMM-Pi node.  This has several benefits:
 
@@ -26,8 +26,8 @@ HSMM-Pi has been tested to work with the Raspberry Pi running the Raspbian OS, a
 
 Raspberry-Pi Node:
 
- *  Raspberry Pi (256MB or 512MB of RAM will work)
- *  USB WiFi adapter (tested with the N150 adapter using the Ralink 5370 chipset)
+ *  Raspberry Pi (256MB, 512MB or 1GB of RAM will work)
+ *  USB WiFi adapter (tested with the N150 adapter using the Ralink 5370 chipset, and with the Alfa AWSU036NH)
  *  SD memory card (4GB minimum)
 
 Beaglebone Black Node:

--- a/install.sh
+++ b/install.sh
@@ -31,6 +31,9 @@ sudo apt-get install -y \
     libnet-gpsd3-perl \
     ntp
 
+# Remove ifplugd if present, as it interferes with olsrd
+sudo apt-get remove ifplugd
+
 # Install cakephp with Pear
 sudo pear channel-discover pear.cakephp.org
 sudo pear install cakephp/CakePHP-2.4.10

--- a/install.sh
+++ b/install.sh
@@ -129,8 +129,8 @@ cd /var/tmp
 git clone git://olsr.org/olsrd.git
 cd olsrd
 
-# Checkout the latest 0.6.7 release, have seen intermittent problems with 0.6.5
-git checkout release-0.6.7
+# Checkout the latest release
+git checkout release-0.6.8
 
 # Apply BBHN patch to olsrd
 patch -p1 < ../bbhn_packages/net/olsrd/patches/002-mode_secure-timediff-fix

--- a/install.sh
+++ b/install.sh
@@ -120,10 +120,6 @@ sudo ln -fs ../mods-available/rewrite.load
 sudo cp ${PROJECT_HOME}/src/etc/apache2/conf.d/hsmm-pi.conf /etc/apache2/conf.d/hsmm-pi.conf
 sudo service apache2 restart
 
-# Download BBHN packages (needed for olsrd patch)
-cd /var/tmp
-git clone git://ubnt.hsmm-mesh.org/bbhn_packages
-
 # Download and build olsrd
 cd /var/tmp
 git clone git://olsr.org/olsrd.git
@@ -131,9 +127,6 @@ cd olsrd
 
 # Checkout the latest release
 git checkout release-0.6.8
-
-# Apply BBHN patch to olsrd
-patch -p1 < ../bbhn_packages/net/olsrd/patches/002-mode_secure-timediff-fix
 
 # patch the Makefile configuration to produce position-independent code (PIC)
 # applies only to ARM architecture (i.e. Beaglebone/Beagleboard)
@@ -161,7 +154,6 @@ sudo cp ${PROJECT_HOME}/src/etc/default/olsrd /etc/default/olsrd
 
 cd /var/tmp
 rm -rf /var/tmp/olsrd
-rm -rf /var/tmp/bbhn_packages
 
 sudo rm -f /etc/olsrd.conf
 sudo ln -fs /etc/olsrd/olsrd.conf /etc/olsrd.conf

--- a/install.sh
+++ b/install.sh
@@ -32,7 +32,7 @@ sudo apt-get install -y \
     ntp
 
 # Remove ifplugd if present, as it interferes with olsrd
-sudo apt-get remove ifplugd
+sudo apt-get remove -y ifplugd
 
 # Install cakephp with Pear
 sudo pear channel-discover pear.cakephp.org


### PR DESCRIPTION
This merge fixes a long-standing bug where olsrd fails to start properly some of the time. The problem was that ifplugd was grabbing the wireless interface and preventing olsrd from reconfiguring it. The install script now removes ifplugd if it's present.

I've also removed the olsrd secure patch, as I'm not convinced it's necessary, and BBHN has in any case abandoned olsrd secure.

Finally, I made a few updates to the documentation.