### PR TITLE
Fix services

### DIFF
--- a/src/var/www/hsmm-pi/Config/bootstrap.php
+++ b/src/var/www/hsmm-pi/Config/bootstrap.php
@@ -109,4 +109,4 @@ CakeLog::config('error', array(
 	'file' => 'error',
 ));
 
-Configure::write('App.version','0.6.1');
+Configure::write('App.version','0.6.2');

--- a/src/var/www/hsmm-pi/Controller/AppController.php
+++ b/src/var/www/hsmm-pi/Controller/AppController.php
@@ -194,7 +194,7 @@ LoadPlugin \"olsrd_dyn_gw_plain.so.0.4\"
 		if ($network_services != NULL && sizeof($network_services) > 0) {
 			foreach ($network_services as $service) {
 				$olsrd_network_services .= "
-    PlParam \"service\" \"" . $service['NetworkService']['service_protocol_name'] . "://" . $network_setting['NetworkSetting']['node_name'] . ".local.mesh:" . $service['NetworkService']['forwarding_port'] . "|" . $service['NetworkService']['protocol'] . "|" . $service['NetworkService']['name'] . "\"
+    PlParam \"service\" \"" . $service['NetworkService']['service_protocol_name'] . "://" . $network_setting['NetworkSetting']['node_name'] . ":" . $service['NetworkService']['forwarding_port'] . "/|" . $service['NetworkService']['protocol'] . "|" . $service['NetworkService']['name'] . "\"
 ";
 			}
 		}

--- a/src/var/www/hsmm-pi/View/NetworkServices/index.ctp
+++ b/src/var/www/hsmm-pi/View/NetworkServices/index.ctp
@@ -42,7 +42,7 @@ foreach ($services as $service) {
 	  <td><?php echo $service['NetworkService']['port'];?></td>
 	  <td><?php echo $service['NetworkService']['protocol'];?></td>
 	  <td><?php echo $service['NetworkService']['forwarding_port'];?></td>
-	  <td><a href="<?php echo $service['NetworkService']['service_protocol_name'] . "://" . $node_name . ".local.mesh:" . $service['NetworkService']['forwarding_port'];?>"><?php echo $service['NetworkService']['service_protocol_name'] . "://" . $node_name . ".local.mesh:" . $service['NetworkService']['forwarding_port'];?></a></td>
+	  <td><a href="<?php echo $service['NetworkService']['service_protocol_name'] . "://" . $node_name . ":" . $service['NetworkService']['forwarding_port'] . '/';?>"><?php echo $service['NetworkService']['service_protocol_name'] . "://" . $node_name . ":" . $service['NetworkService']['forwarding_port'] . '/';?></a></td>
 	  <td>
 	        <?php
 echo $this->Html->link('', array(


### PR DESCRIPTION
Make services behave like in AREDN by removing `.local.mesh` and appending a trailing slash. After these changes, services are visible on AREDN nodes. This partially addresses https://github.com/urlgrey/hsmm-pi/issues/67.