### PR TITLE
Fix GPS script bug

### DIFF
--- a/src/etc/cron.d/hsmm-pi
+++ b/src/etc/cron.d/hsmm-pi
@@ -3,5 +3,4 @@
 * *  * * *     root   bash -c "[ -e /var/data/hsmm-pi/reboot ] && rm -f /var/data/hsmm-pi/reboot && /sbin/init 6" 2>/dev/null
 * *  * * *     root   bash -c "[ -e /var/data/hsmm-pi/shutdown ] && rm -f /var/data/hsmm-pi/shutdown && /sbin/init 0" 2>/dev/null
 * *  * * *     root   bash -c "[ -e /var/run/gpsd.sock ] && [ ! -e /var/run/read_gps_coordinates.lock ] && /usr/local/bin/read_gps_coordinates.pl" 2>/dev/null
-* *  * * *     root   bash -c "[ -e /var/run/read_gps_coordinates.lock ] && find /var/run/read_gps_coordinates.lock -mmin +5 -exec rm -f {} \;" 2>/dev/null
 0,10,20,30,40,50 * * * *    root   /usr/local/bin/callsign_announcement.sh 2>/dev/null

--- a/src/var/www/hsmm-pi/Config/bootstrap.php
+++ b/src/var/www/hsmm-pi/Config/bootstrap.php
@@ -109,4 +109,4 @@ CakeLog::config('error', array(
 	'file' => 'error',
 ));
 
-Configure::write('App.version','0.7.1');
+Configure::write('App.version','0.7.2');

--- a/src/var/www/hsmm-pi/webroot/files/rc.local.template
+++ b/src/var/www/hsmm-pi/webroot/files/rc.local.template
@@ -18,6 +18,7 @@
 #
 # By default this script does nothing.
 
+rm -f /var/run/read_gps_coordinates.lock
 
 # Make attempts to reinitialize the WLAN adapter if no IP reported
 INET_IFACE={wifi_adapter_name}


### PR DESCRIPTION
When GPS is not in use, the read_gps_coordinates.pl script waits indefinitely for GPS data. But a cron job was deleting its lock file every five minutes, causing another copy to be spawned. This continued until memory filled up.

I've fixed this by removing the cron job that deletes the lock file, and moving that task to rc.local.