### PR TITLE
Release 0.8.1.

### DIFF
--- a/src/var/www/hsmm-pi/Config/bootstrap.php
+++ b/src/var/www/hsmm-pi/Config/bootstrap.php
@@ -109,4 +109,4 @@ CakeLog::config('error', array(
 	'file' => 'error',
 ));
 
-Configure::write('App.version','0.8.0');
+Configure::write('App.version','0.8.1');


### PR DESCRIPTION
@urlgrey I just tested this on a Raspberry Pi and it's working well, so we may as well call it version 0.8.1.