### PR TITLE
Don't install gpsd-clients package.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -32,7 +32,6 @@ sudo apt-get install -y \
     bison \
     flex \
     gpsd \
-    gpsd-clients \
     libnet-gpsd3-perl \
     ntp
 


### PR DESCRIPTION
Fixes https://github.com/urlgrey/hsmm-pi/issues/88

@urlgrey @mathisono 

Removing gpsd-clients from the install script results in 48 less packages being installed on Raspbian Jessie Lite, and also reduces the amount of data that needs to be downloaded (by 15.9 MB) and the amount of disk space used (by 62.5 MB). Anyone who wants gpsd-clients can still install them manually before or after running the HSMM-Pi install script.