### PR TITLE
Switch from PEAR to Composer.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 src/var/www/hsmm-pi/tmp/
+src/var/www/hsmm-pi/Vendor/
+src/var/www/hsmm-pi/composer.phar

--- a/install.sh
+++ b/install.sh
@@ -24,8 +24,8 @@ sudo apt-get install -y \
     apache2 \
     php5 \
     sqlite \
-    php-pear \
-    php5-sqlite  \
+    php5-mcrypt \
+    php5-sqlite \
     dnsmasq \
     sysv-rc-conf \
     make \
@@ -50,10 +50,6 @@ fi
 sudo bash -c "echo 'nameserver 8.8.8.8' > /etc/resolv.conf"
 sudo chgrp www-data /etc/resolv.conf
 sudo chmod g+w /etc/resolv.conf
-
-# Install cakephp with Pear
-sudo pear channel-discover pear.cakephp.org
-sudo pear install cakephp/CakePHP-2.8.3
 
 # Checkout the HSMM-Pi project
 if [ ! -e ${PROJECT_HOME} ]; then
@@ -99,6 +95,14 @@ if [ ! -e /usr/local/bin/read_gps_coordinates.pl ]; then
     sudo chgrp www-data /usr/local/bin/read_gps_coordinates.pl
     sudo chmod 775 /usr/local/bin/read_gps_coordinates.pl
 fi
+
+# Install Composer
+php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+php composer-setup.php
+php -r "unlink('composer-setup.php');"
+
+# Install CakePHP with Composer
+php composer.phar install
 
 sudo mkdir -p /var/data/hsmm-pi
 sudo chown root.www-data /var/data/hsmm-pi

--- a/src/var/www/hsmm-pi/Console/cake.php
+++ b/src/var/www/hsmm-pi/Console/cake.php
@@ -27,7 +27,7 @@ if (function_exists('ini_set')) {
 
 	// the following line differs from its sibling
 	// /app/Console/cake.php
-	ini_set('include_path', $root . PATH_SEPARATOR .  $ds . 'usr' . $ds . 'share' . $ds . 'php' . PATH_SEPARATOR . ini_get('include_path'));
+	ini_set('include_path', $root . PATH_SEPARATOR . $root.$ds.'hsmm-pi'.$ds.'Vendor'.$ds.'cakephp'.$ds.'cakephp'.$ds.'lib' . PATH_SEPARATOR . ini_get('include_path'));
 }
 
 if (!include ($dispatcher)) {

--- a/src/var/www/hsmm-pi/composer.json
+++ b/src/var/www/hsmm-pi/composer.json
@@ -1,0 +1,9 @@
+{
+    "name": "hsmm-pi",
+    "require": {
+        "cakephp/cakephp": "2.8.*"
+    },
+    "config": {
+        "vendor-dir": "Vendor/"
+    }
+}

--- a/src/var/www/hsmm-pi/composer.lock
+++ b/src/var/www/hsmm-pi/composer.lock
@@ -1,0 +1,63 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "hash": "31bc1f1a6efce99b975443c0d1cc25c7",
+    "content-hash": "c2493b12b98e88edfd42dd5ba994f0c2",
+    "packages": [
+        {
+            "name": "cakephp/cakephp",
+            "version": "2.8.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cakephp/cakephp.git",
+                "reference": "8cd5a64c27abf47e02aba29403428f8e4937de45"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cakephp/cakephp/zipball/8cd5a64c27abf47e02aba29403428f8e4937de45",
+                "reference": "8cd5a64c27abf47e02aba29403428f8e4937de45",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mcrypt": "*",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "cakephp/cakephp-codesniffer": "^1.0.0",
+                "cakephp/debug_kit": "^2.2.0",
+                "phpunit/phpunit": "3.7.*"
+            },
+            "bin": [
+                "lib/Cake/Console/cake"
+            ],
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "CakePHP Community",
+                    "homepage": "https://github.com/cakephp/cakephp/graphs/contributors"
+                }
+            ],
+            "description": "The CakePHP framework",
+            "homepage": "http://cakephp.org",
+            "keywords": [
+                "framework"
+            ],
+            "time": "2016-05-03 02:18:41"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}

--- a/src/var/www/hsmm-pi/webroot/index.php
+++ b/src/var/www/hsmm-pi/webroot/index.php
@@ -63,7 +63,7 @@ if (!defined('APP_DIR')) {
  * The following line differs from its sibling
  * /app/webroot/index.php
  */
-//define('CAKE_CORE_INCLUDE_PATH',  DS . 'usr' . DS . 'share' . DS . 'php');
+define('CAKE_CORE_INCLUDE_PATH', ROOT.DS.APP_DIR.DS.'Vendor'.DS.'cakephp'.DS.'cakephp'.DS.'lib');
 
 /**
  * Editing below this line should NOT be necessary.


### PR DESCRIPTION
Fixes https://github.com/urlgrey/hsmm-pi/issues/96.

For review @urlgrey @cbegg50
/cc @syelnmh

This change switches from PEAR to Composer, which is CakePHP's only supported install mechanism beginning in version 3. I tested this on a Raspberry Pi 3 and it worked well.