### PR TITLE
Check out olsrd by tag instead of branch.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -138,7 +138,7 @@ sudo service apache2 restart
 
 # Download and build olsrd
 cd /var/tmp
-git clone --branch release-0.6.8 --depth 1 https://github.com/OLSR/olsrd.git
+git clone --branch v0.6.8.1 --depth 1 https://github.com/OLSR/olsrd.git
 cd olsrd
 
 # patch the Makefile configuration to produce position-independent code (PIC)


### PR DESCRIPTION
@urlgrey @tylert

The 0.6.8 branch of olsrd no longer exists, and so the installer fails. To fix that, I've changed the `git clone` command to check out the `0.6.8.1` release by its tag.